### PR TITLE
fix(etl): sync_sqlite_to_sqlserver matches by Name not Code

### DIFF
--- a/etl/sync_sqlite_to_sqlserver.py
+++ b/etl/sync_sqlite_to_sqlserver.py
@@ -25,24 +25,44 @@ CONN_STR = (
 )
 
 
+def _normkey(s):
+    """Normalize a country/category/field name for cross-DB matching.
+    Lowercase + collapse internal whitespace. Country Code is NOT used as a
+    key because Gutenberg-era codes have collisions (e.g. 'ma' = both
+    Madagascar and 'Man, Isle of'; 'ca' = both Canada and Cape Verde).
+    Names are unique within a year and are stable across both DBs."""
+    if s is None:
+        return ""
+    return " ".join(str(s).split()).lower()
+
+
 def sync_country_fields(sc, mc, sql_conn, years, dry_run=False):
-    """Sync CountryFields.Content from SQLite to SQL Server."""
+    """Sync CountryFields.Content from SQLite to SQL Server.
+    Match by (Name, CategoryTitle, FieldName) — NOT by Code, because the
+    1990-1995 Gutenberg parser's make_code() generates colliding 2-letter
+    codes for ~16 country pairs (Madagascar/Isle of Man, Canada/Cape Verde,
+    Somalia/Soviet Union, etc.). Matching by Code silently cross-pollinates
+    these countries' content. See raw-sources/SQL_SERVER_CLEANUP_PLAN.md.
+    """
     total_updated = 0
 
     for year in years:
-        # Build SQLite lookup: (Code, CategoryTitle, FieldName) -> Content
+        # Build SQLite lookup: (NameKey, CategoryTitle, FieldName) -> Content
         sc.execute("""
-            SELECT co.Code, cc.CategoryTitle, cf.FieldName, cf.Content
+            SELECT co.Name, cc.CategoryTitle, cf.FieldName, cf.Content
             FROM CountryFields cf
             JOIN Countries co ON cf.CountryID = co.CountryID
             JOIN CountryCategories cc ON cf.CategoryID = cc.CategoryID
             WHERE co.Year = ?
         """, (year,))
-        sqlite_lookup = {(code, cat, fn): content for code, cat, fn, content in sc.fetchall()}
+        sqlite_lookup = {
+            (_normkey(name), _normkey(cat), _normkey(fn)): content
+            for name, cat, fn, content in sc.fetchall()
+        }
 
         # Get SQL Server fields for this year
         mc.execute("""
-            SELECT cf.FieldID, co.Code, cc.CategoryTitle, cf.FieldName, cf.Content
+            SELECT cf.FieldID, co.Name, cc.CategoryTitle, cf.FieldName, cf.Content
             FROM CountryFields cf
             JOIN Countries co ON cf.CountryID = co.CountryID
             JOIN CountryCategories cc ON cf.CategoryID = cc.CategoryID
@@ -50,8 +70,8 @@ def sync_country_fields(sc, mc, sql_conn, years, dry_run=False):
         """, year)
 
         year_updated = 0
-        for fid, code, cat, fname, old_content in mc.fetchall():
-            key = (code, cat, fname)
+        for fid, name, cat, fname, old_content in mc.fetchall():
+            key = (_normkey(name), _normkey(cat), _normkey(fname))
             if key in sqlite_lookup:
                 new_content = sqlite_lookup[key]
                 if new_content and new_content != old_content:
@@ -71,20 +91,22 @@ def sync_country_fields(sc, mc, sql_conn, years, dry_run=False):
 
 
 def sync_master_countries(sc, mc, sql_conn, dry_run=False):
-    """Sync MasterCountryID links from SQLite to SQL Server."""
+    """Sync MasterCountryID links from SQLite to SQL Server.
+    Match by (Year, Name) — see sync_country_fields docstring for why
+    Code is not used."""
     sc.execute("""
-        SELECT co.Year, co.Code, co.MasterCountryID
+        SELECT co.Year, co.Name, co.MasterCountryID
         FROM Countries co
         WHERE co.MasterCountryID IS NOT NULL
     """)
     sqlite_links = {}
-    for year, code, mid in sc.fetchall():
-        sqlite_links[(year, code)] = mid
+    for year, name, mid in sc.fetchall():
+        sqlite_links[(year, _normkey(name))] = mid
 
-    mc.execute("SELECT CountryID, Year, Code, MasterCountryID FROM Countries")
+    mc.execute("SELECT CountryID, Year, Name, MasterCountryID FROM Countries")
     updated = 0
-    for cid, year, code, old_mid in mc.fetchall():
-        key = (year, code)
+    for cid, year, name, old_mid in mc.fetchall():
+        key = (year, _normkey(name))
         if key in sqlite_links:
             new_mid = sqlite_links[key]
             if new_mid != old_mid:

--- a/raw-sources/SQL_SERVER_CLEANUP_PLAN.md
+++ b/raw-sources/SQL_SERVER_CLEANUP_PLAN.md
@@ -1,8 +1,85 @@
 # SQL Server Cleanup Plan
 
 Generated: 2026-05-27
-Status: INVESTIGATION ONLY — no destructive changes have been executed.
+**Status: EXECUTED on 2026-05-28. SQL Server is now in sync with SQLite.**
 Author: handoff from L0-L3b validation pass.
+
+## Outcome (post-execution)
+
+Final row counts after cleanup:
+
+| Table | SQLite | SQL Server | Status |
+|---|---|---|---|
+| Countries | 9,535 | 9,535 | MATCH |
+| CountryFields | 1,071,489 | 1,071,489 | MATCH (was +112 stale) |
+| CountryCategories | 83,682 | 83,673 | -9 (orphaned from deleted Serbia rb categories; benign) |
+| MasterCountries | 284 | 284 | MATCH |
+| FieldNameMappings | 1,132 | 1,132 | MATCH |
+
+All 36 years of CountryFields match exactly between the two DBs. Madagascar
+Territorial sea now reads `12 nm` in both (was `3 nm` in SQL Server).
+Somalia Birth rate now reads `47 births/1,000` in both (was `18` in SQL
+Server). The Serbia 2008 duplicate is gone.
+
+## Root cause uncovered during execution
+
+The sync script `etl/sync_sqlite_to_sqlserver.py` was originally keyed by
+`(Year, Code, CategoryTitle, FieldName)`. Within 1990-2001 Gutenberg data,
+seven Code values collide because the parser's `make_code()` produces
+2-letter codes by truncating country names:
+
+| Code | Colliding countries |
+|---|---|
+| `'st'` (×5) | St. Helena, St. Kitts and Nevis, St. Lucia, St. Pierre and Miquelon, St. Vincent and the Grenadines |
+| `'so'` (×2) | **Somalia, Soviet Union** |
+| `'ma'` (×2) | Madagascar, Man, Isle of |
+| `'ca'` (×2) | Canada, Cape Verde |
+| `'pa'` (×2) | Pacific Islands, Paraguay |
+| `'ym'` (×2) | Yemen Arab Republic, Yemen, People's Democratic Republic of |
+| `'iz'` (×2) | Iraq, Iraq-Saudi Arabia Neutral Zone |
+
+When the sync built a `(Code, Cat, Field) -> Content` lookup dict from
+SQLite, the second country with a colliding code silently overwrote the
+first. Then when comparing against SQL Server rows, the dict's last-wins
+value would match SQL Server's stored value (which was itself the result
+of an earlier sync run hitting the same bug), so the sync would report
+0 updates needed — even though Madagascar had Isle of Man's value and
+Somalia had Soviet Union's value.
+
+**Fix:** changed the key from `(Code, Cat, Field)` to
+`(Name, Cat, Field)`. Country Names are unique within a year. Same fix
+applied to `sync_master_countries` which keyed by `(Year, Code)`.
+
+The fixed script lives in `etl/sync_sqlite_to_sqlserver.py`. After the fix,
+the dry-run correctly identified 2,621 CountryFields updates and 33
+MasterCountryID updates concentrated in 1990-2001.
+
+## Execution log (2026-05-28)
+
+| Step | Result |
+|---|---|
+| 0. Backup CIA_WorldFactbook to MSSQL Backup dir | 442 MB raw / 133 MB compressed; `RESTORE VERIFYONLY` passed |
+| 1. Fix sync script (Code -> Name in both functions) | Committed |
+| 2. Dry-run | 2,621 CountryFields updates + 33 MasterCountryID updates predicted |
+| 3. Apply CountryFields sync | 2,621 rows updated across 1990-2017; Madagascar / Somalia / etc. verified |
+| 4. Drop `UQ_MasterCountries_CanonicalCode` (SQLite has no such constraint and intentionally lets dissolved entities share codes, e.g. Slovakia + Czechoslovakia both = `'LO'`) | Constraint dropped |
+| 5. INSERT 3 missing MasterCountries (Soviet Union UR, Czechoslovakia LO, Yugoslavia YU; EntityType `'dissolved'`) | Total now 284 |
+| 6. DELETE Serbia 2008 stale `'rb'` row + 114 CountryFields + 9 CountryCategories children | Countries Year=2008 went from 263 to 262 |
+| 7. UPDATE 3 FieldNameMappings rows (CanonicalName `'Military expenditures - percent of GDP'` -> `'Military expenditures'`) | 3 rows updated |
+| 8. Re-run sync for MasterCountryID linking | 33 MasterCountryID updates applied (was previously failing on FK to missing MasterCountries) |
+| 9. Insert 2 missing Serbia 2008 CountryFields (`Economic aid - recipient`, `Population below poverty line`) that were orphaned to the deleted `'rb'` row | Serbia 2008 row count now 119 in both DBs |
+| 10. Re-validate via L3b | Matched rows: 1,063,060 -> 1,065,234; per-year row counts: all 36 years match exactly |
+
+Total elapsed: ~30 minutes including investigation and verification.
+Backup remains in place at the SQL Server default backup directory.
+
+## What we are NOT doing (deferred)
+
+- **Not migrating `FieldValues` to SQL Server.** No consumer. Webapp reads
+  SQLite. Same reasoning as the original plan section 3.
+- **Not migrating `ISOCountryCodes` to SQL Server.** No consumer.
+- **Not shrinking the SQL Server data file.** Optional disk reclamation;
+  can be done off-hours with `DBCC SHRINKFILE` if desired.
 
 ## 1. Diagnosis
 


### PR DESCRIPTION
## Summary

Fixes a silent corruption bug in \`etl/sync_sqlite_to_sqlserver.py\` and runs the fixed sync to restore SQL Server alignment with the canonical SQLite database.

## The bug

The Gutenberg-era parser's \`make_code()\` function generates colliding 2-letter country codes by truncating names. **7 codes collide across 16 country pairs** in 1990-2001 data:

| Code | Colliding countries |
|---|---|
| \`'st'\` (×5) | St. Helena, Kitts, Lucia, Pierre and Miquelon, Vincent |
| \`'so'\` (×2) | **Somalia, Soviet Union** |
| \`'ma'\` (×2) | **Madagascar, Man, Isle of** |
| \`'ca'\` (×2) | **Canada, Cape Verde** |
| \`'pa'\` (×2) | Pacific Islands, Paraguay |
| \`'ym'\` (×2) | Yemen Arab Republic, Yemen PDR |
| \`'iz'\` (×2) | Iraq, Iraq-Saudi Arabia Neutral Zone |

The original sync built a \`(Year, Code, Cat, Field) -> Content\` lookup from SQLite. On collisions, the second country silently overwrote the first in the dict. SQL Server then matched the wrong value as \"already synced\" and reported 0 updates needed.

Visible symptom: Madagascar's 1990 Territorial sea read \`'3 nm'\` in SQL Server (Isle of Man's value); Somalia's Birth rate read \`'18 births/1,000'\` (Soviet Union's value); ~2,600 rows of cross-country leakage.

## The fix

Two functions in \`sync_sqlite_to_sqlserver.py\` change their matching key from \`Code\` to \`Name\`. Country Names are unique within a year. New \`_normkey()\` helper does case+whitespace normalization for cross-DB matching.

After the fix, dry-run identifies **2,621 CountryFields updates** and **33 MasterCountryID updates** concentrated in 1990-2001.

## Execution log (also documented in \`raw-sources/SQL_SERVER_CLEANUP_PLAN.md\`)

1. Backup SQL Server CIA_WorldFactbook (verified)
2. Apply fixed sync — 2,621 CountryFields rows corrected
3. Drop \`UQ_MasterCountries_CanonicalCode\` (SQLite intentionally lets dissolved entities share codes)
4. Insert 3 missing MasterCountries (Soviet Union, Czechoslovakia, Yugoslavia)
5. Delete stale Serbia 2008 \`'rb'\` row + 114 child fields + 9 categories
6. Update 3 FieldNameMappings rows
7. Re-run sync for MasterCountryID linking (33 updates)
8. Insert 2 orphaned Serbia 2008 fields
9. Re-validate via L3b

## Result

Final row counts SQLite vs SQL Server:

| Table | Match? |
|---|---|
| Countries | ✓ MATCH (9,535) |
| CountryFields | ✓ MATCH (1,071,489) |
| MasterCountries | ✓ MATCH (284) |
| FieldNameMappings | ✓ MATCH (1,132) |
| CountryCategories | -9 (orphans from cleanup, benign) |

All 36 years of CountryFields row counts match exactly. Cross-country content leakage is corrected.

## Test plan

- [x] Dry-run shows expected count of updates
- [x] Spot-check key rows after sync (Madagascar, Somalia, etc.) match raw .txt
- [x] L3b re-validation: per-year row counts match exactly
- [x] No regression in JSON years 2021-2025 (still 0 diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)